### PR TITLE
Add automatic GSI configuration file generation

### DIFF
--- a/CounterStrike2GSI/CMakeLists.txt
+++ b/CounterStrike2GSI/CMakeLists.txt
@@ -64,6 +64,7 @@ SET(SOURCES
     StateHandlers/PlayerHandler.cs
     StateHandlers/ProviderHandler.cs
     StateHandlers/RoundHandler.cs
+    Utils/SteamUtils.cs
 )
 
 SET(README "${CMAKE_SOURCE_DIR}/README.md")

--- a/CounterStrike2GSI/CMakeLists.txt
+++ b/CounterStrike2GSI/CMakeLists.txt
@@ -17,6 +17,7 @@ INCLUDE(CSharpUtilities)
 
 SET(SOURCES
     CS2EventsInterface.cs
+    CS2GSIFile.cs
     EventDispatcher.cs
     EventHandler.cs
     EventsInterface.cs

--- a/CounterStrike2GSI/CS2GSIFile.cs
+++ b/CounterStrike2GSI/CS2GSIFile.cs
@@ -1,0 +1,88 @@
+﻿using CounterStrike2GSI.Utils;
+using System;
+using System.IO;
+
+namespace CounterStrike2GSI
+{
+    /// <summary>
+    /// Class handling Game State Integration configuration file generation.
+    /// </summary>
+    public class CS2GSIFile
+    {
+        /// <summary>
+        /// Attempts to create a Game State Integration configuraion file.<br/>
+        /// The configuration will target <c>http://localhost:{port}/</c> address.<br/>
+        /// Returns true on success, false otherwise.
+        /// </summary>
+        /// <param name="name">The name of your integration.</param>
+        /// <param name="port">The port for your integration.</param>
+        /// <returns>Returns true on success, false otherwise.</returns>
+        public static bool CreateFile(string name, int port)
+        {
+            return CreateFile(name, $"http://localhost:{port}/");
+        }
+
+        /// <summary>
+        /// Attempts to create a Game State Integration configuraion file.<br/>
+        /// The configuration will target the specified URI address.<br/>
+        /// Returns true on success, false otherwise.
+        /// </summary>
+        /// <param name="name">The name of your integration.</param>
+        /// <param name="uri">The URI for your integration.</param>
+        /// <returns>Returns true on success, false otherwise.</returns>
+        public static bool CreateFile(string name, string uri)
+        {
+            string csgo_path = SteamUtils.GetGamePath(730);
+
+            try
+            {
+                if (!string.IsNullOrWhiteSpace(csgo_path))
+                {
+                    string gsifolder = csgo_path + @"\game\csgo\cfg\";
+                    Directory.CreateDirectory(gsifolder);
+                    string gsifile = gsifolder + @$"gamestate_integration_{name}.cfg";
+
+                    ACF provider_configuration = new ACF();
+                    provider_configuration.Items["provider"] = "1";
+                    provider_configuration.Items["tournamentdraft"] = "1";
+                    provider_configuration.Items["map"] = "1";
+                    provider_configuration.Items["map_round_wins"] = "1";
+                    provider_configuration.Items["round"] = "1";
+                    provider_configuration.Items["player_id"] = "1";
+                    provider_configuration.Items["player_state"] = "1";
+                    provider_configuration.Items["player_weapons"] = "1";
+                    provider_configuration.Items["player_match_stats"] = "1";
+                    provider_configuration.Items["player_position"] = "1";
+                    provider_configuration.Items["phase_countdowns"] = "1";
+                    provider_configuration.Items["allplayers_id"] = "1";
+                    provider_configuration.Items["allplayers_state"] = "1";
+                    provider_configuration.Items["allplayers_match_stats"] = "1";
+                    provider_configuration.Items["allplayers_weapons"] = "1";
+                    provider_configuration.Items["allplayers_position"] = "1";
+                    provider_configuration.Items["allgrenades"] = "1";
+                    provider_configuration.Items["bomb"] = "1";
+
+                    ACF gsi_configuration = new ACF();
+                    gsi_configuration.Items["uri"] = uri;
+                    gsi_configuration.Items["timeout"] = "5.0";
+                    gsi_configuration.Items["buffer"] = "0.1";
+                    gsi_configuration.Items["throttle"] = "0.1";
+                    gsi_configuration.Items["heartbeat"] = "10.0";
+                    gsi_configuration.Children["data"] = provider_configuration;
+
+                    ACF gsi = new ACF();
+                    gsi.Children[$"{name} Integration Configuration"] = gsi_configuration;
+
+                    File.WriteAllText(gsifile, gsi.ToString());
+
+                    return true;
+                }
+            }
+            catch (Exception)
+            {
+            }
+
+            return false;
+        }
+    }
+}

--- a/CounterStrike2GSI/GameStateListener.cs
+++ b/CounterStrike2GSI/GameStateListener.cs
@@ -67,7 +67,12 @@ namespace CounterStrike2GSI
         /// <summary>
         /// Gets the port that is being listened.
         /// </summary>
-        public int Port { get { return _port; } }
+        public int Port => _port;
+
+        /// <summary>
+        /// Gets the URI that is being listened.
+        /// </summary>
+        public string URI => _uri;
 
         /// <summary>
         /// Returns whether or not the listener is running.
@@ -83,6 +88,7 @@ namespace CounterStrike2GSI
 
         private bool _is_running = false;
         private int _port;
+        private string _uri;
         private HttpListener _http_listener;
         private AutoResetEvent _wait_for_connection = new AutoResetEvent(false);
         private GameState _previous_game_state = new GameState();
@@ -123,8 +129,9 @@ namespace CounterStrike2GSI
         public GameStateListener(int port) : this()
         {
             _port = port;
+            _uri = $"http://localhost:{_port}/";
             _http_listener = new HttpListener();
-            _http_listener.Prefixes.Add("http://localhost:" + port + "/");
+            _http_listener.Prefixes.Add(_uri);
         }
 
         /// <summary>
@@ -147,9 +154,19 @@ namespace CounterStrike2GSI
             }
 
             _port = Convert.ToInt32(PortMatch.Groups[1].Value);
-
+            _uri = URI;
             _http_listener = new HttpListener();
             _http_listener.Prefixes.Add(URI);
+        }
+
+        /// <summary>
+        /// Attempts to create a Game State Integration configuraion file.
+        /// </summary>
+        /// <param name="name">The name of your integration.</param>
+        /// <returns>Returns true on success, false otherwise.</returns>
+        public bool GenerateGSIConfigFile(string name)
+        {
+            return CS2GSIFile.CreateFile(name, _uri);
         }
 
         /// <summary>

--- a/CounterStrike2GSI/StateHandlers/PlayerHandler.cs
+++ b/CounterStrike2GSI/StateHandlers/PlayerHandler.cs
@@ -37,7 +37,7 @@ namespace CounterStrike2GSI
             _provider_cache = evt.New;
         }
 
-            private void OnPlayerUpdated(CS2GameEvent e)
+        private void OnPlayerUpdated(CS2GameEvent e)
         {
             PlayerUpdated evt = (e as PlayerUpdated);
 

--- a/CounterStrike2GSI/Utils/SteamUtils.cs
+++ b/CounterStrike2GSI/Utils/SteamUtils.cs
@@ -1,0 +1,330 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace CounterStrike2GSI.Utils
+{
+    /// <summary>
+    /// Class that serializes and deserializes ACF file format.
+    /// </summary>
+    public class ACF
+    {
+        /// <summary>
+        /// The items of this ACF element.
+        /// </summary>
+        public Dictionary<string, string> Items => _items;
+
+        /// <summary>
+        /// The children of this ACF element.
+        /// </summary>
+        public Dictionary<string, ACF> Children => _children;
+
+        private Dictionary<string, string> _items = new Dictionary<string, string>();
+        private Dictionary<string, ACF> _children = new Dictionary<string, ACF>();
+
+        private static Dictionary<char, char> _escape_characters = new Dictionary<char, char>() {
+            { 'r', '\r' },
+            { 'n', '\n' },
+            { 't', '\t' },
+            { '\'', '\'' },
+            { '"', '"' },
+            { '\\', '\\' },
+            { 'b', '\b' },
+            { 'f', '\f' },
+            { 'v', '\v' }
+        };
+
+        public ACF()
+        {
+        }
+
+        public ACF(string filename)
+        {
+            if (File.Exists(filename))
+            {
+                using (FileStream file_stream = new FileStream(filename, FileMode.Open))
+                {
+                    ParseStream(new StreamReader(file_stream));
+                }
+            }
+        }
+
+        internal ACF(StreamReader stream)
+        {
+            ParseStream(stream);
+        }
+
+        private void ParseStream(StreamReader stream)
+        {
+            bool seeking_brace = false;
+
+            if ((char)stream.Peek() == '{')
+            {
+                // Consume {
+                stream.Read();
+                seeking_brace = true;
+            }
+
+            while (!stream.EndOfStream)
+            {
+                if (seeking_brace && (char)stream.Peek() == '}')
+                {
+                    // Consume }
+                    stream.Read();
+                    break;
+                }
+
+                // Attempt to read the item key
+                object key = ReadValue(stream);
+
+                if (key != null && key is string str_key)
+                {
+                    object value = ReadValue(stream);
+
+                    if (value != null)
+                    {
+                        if (value is string str_value)
+                        {
+                            _items.Add(str_key.ToLowerInvariant(), str_value);
+                        }
+                        else if (value is ACF acf_value)
+                        {
+                            _children.Add(str_key.ToLowerInvariant(), acf_value);
+                        }
+                    }
+                }
+
+                // Skip over any whitespace characters to get to next value
+                while (char.IsWhiteSpace((char)stream.Peek()))
+                {
+                    stream.Read();
+                }
+            }
+        }
+
+        private object ReadValue(StreamReader stream)
+        {
+            object return_value = null;
+
+            // Skip over any whitespace characters to get to next value
+            while (char.IsWhiteSpace((char)stream.Peek()))
+            {
+                stream.Read();
+            }
+
+            char peekchar = (char)stream.Peek();
+
+            if (peekchar.Equals('{'))
+            {
+                return_value = new ACF(stream);
+            }
+            else if (peekchar.Equals('/'))
+            {
+                // Comment, read until end of line
+                stream.ReadLine();
+            }
+            else
+            {
+                return_value = ReadString(stream);
+            }
+
+            return return_value;
+        }
+
+        private string ReadString(StreamReader instream)
+        {
+            StringBuilder builder = new StringBuilder();
+
+            bool isQuote = ((char)instream.Peek()).Equals('"');
+
+            if (isQuote)
+            {
+                instream.Read();
+            }
+
+            for (char chr = (char)instream.Read(); !instream.EndOfStream; chr = (char)instream.Read())
+            {
+
+                if (isQuote && chr.Equals('"') ||
+                    !isQuote && char.IsWhiteSpace(chr)) // Arrived at end of string.
+                {
+                    break;
+                }
+
+                if (chr.Equals('\\')) // Fix up escaped characters.
+                {
+                    // Read next character.
+                    char escape = (char)instream.Read();
+
+                    if (_escape_characters.ContainsKey(escape))
+                    {
+                        builder.Append(_escape_characters[escape]);
+                    }
+                }
+                else
+                {
+                    builder.Append(chr);
+                }
+            }
+
+            return builder.ToString();
+        }
+
+        public string BuildString(int indent_amount = 0)
+        {
+            int longest_key_value = 0;
+
+            foreach (var item_kvp in _items)
+            {
+                if (item_kvp.Key.Length > longest_key_value)
+                {
+                    longest_key_value = item_kvp.Key.Length;
+                }
+            }
+
+            string indentation = "";
+            for (int i = 0; i < indent_amount; i++)
+            {
+                indentation += "    ";
+            }
+
+            StringBuilder stringBuilder = new StringBuilder();
+
+            foreach (var item_kvp in _items)
+            {
+                // Indent beginning
+                stringBuilder.Append(indentation);
+                stringBuilder.Append($"\"{item_kvp.Key}\"");
+                // Pretty print
+                for (int i = item_kvp.Key.Length; i < longest_key_value; i++)
+                {
+                    stringBuilder.Append(' ');
+                }
+                // Separator between the key and value
+                stringBuilder.Append("    ");
+                stringBuilder.Append($"\"{item_kvp.Value}\"");
+                stringBuilder.AppendLine();
+            }
+
+            foreach (var child_kvp in _children)
+            {
+                // Indent beginning
+                stringBuilder.Append(indentation);
+                stringBuilder.AppendLine($"\"{child_kvp.Key}\"");
+                // Opening {
+                stringBuilder.Append(indentation);
+                stringBuilder.AppendLine("{");
+                stringBuilder.Append(child_kvp.Value.BuildString(indent_amount + 1));
+                // Closing }
+                stringBuilder.Append(indentation);
+                stringBuilder.AppendLine("}");
+            }
+
+            return stringBuilder.ToString();
+        }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            return BuildString();
+        }
+
+        /// <inheritdoc/>
+        public override bool Equals(object obj)
+        {
+            return obj is ACF other &&
+                _items.SequenceEqual(other._items) &&
+                _children.SequenceEqual(other._children);
+        }
+
+        /// <inheritdoc/>
+        public override int GetHashCode()
+        {
+            int hashCode = 610350854;
+
+            foreach (var item in _items)
+            {
+                hashCode = hashCode * -379045661 + item.GetHashCode();
+            }
+
+            foreach (var child in _children)
+            {
+                hashCode = hashCode * -379045661 + child.GetHashCode();
+            }
+
+            return hashCode;
+        }
+    }
+
+    /// <summary>
+    /// A class for handling Steam games
+    /// </summary>
+    public static class SteamUtils
+    {
+        /// <summary>
+        /// Retrieves a path to a specified AppID
+        /// </summary>
+        /// <param name="game_id">The game's AppID</param>
+        /// <returns>Path to the location of AppID's install</returns>
+        public static string GetGamePath(int game_id)
+        {
+            try
+            {
+                string steam_path = "";
+
+                if (OperatingSystem.IsWindows())
+                {
+                    try
+                    {
+                        steam_path = (string)Microsoft.Win32.Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\Valve\Steam", "InstallPath", null);
+                        if (string.IsNullOrWhiteSpace(steam_path))
+                        {
+                            steam_path = (string)Microsoft.Win32.Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Valve\Steam", "InstallPath", null);
+                        }
+                    }
+                    catch (Exception)
+                    {
+                        steam_path = "";
+                    }
+                }
+
+                if (String.IsNullOrWhiteSpace(steam_path))
+                {
+                    return null;
+                }
+
+                string libraries_file = Path.Combine(steam_path, "SteamApps", "libraryfolders.vdf");
+                if (File.Exists(libraries_file))
+                {
+                    ACF lib_data = new ACF(libraries_file);
+                    var library_folders = lib_data.Children["libraryfolders"];
+
+                    foreach (var library_entry_kvp in library_folders.Children)
+                    {
+                        var library_entry = library_entry_kvp.Value;
+                        string library_path = library_entry.Items["path"];
+
+                        var manifest_file = Path.Combine(library_path, "steamapps", $"appmanifest_{game_id}.acf");
+                        if (File.Exists(manifest_file))
+                        {
+                            ACF manifest_data = new ACF(manifest_file);
+                            string install_dir = manifest_data.Children["appstate"].Items["installdir"];
+                            string appid_path = Path.Combine(library_path, "steamapps", "common", install_dir);
+                            if (Directory.Exists(appid_path))
+                            {
+                                return appid_path;
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Exception)
+            {
+            }
+
+            return null;
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 Counter-Strike 2 GSI (Game State Integration)
-===================================
+=============================================
 
 [![.NET](https://github.com/antonpup/CounterStrike2GSI/actions/workflows/dotnet.yml/badge.svg?branch=master)](https://github.com/antonpup/CounterStrike2GSI/actions/workflows/dotnet.yml)
-![GitHub Release](https://img.shields.io/github/v/release/antonpup/CounterStrike2GSI)
+[![GitHub Release](https://img.shields.io/github/v/release/antonpup/CounterStrike2GSI)](https://github.com/antonpup/CounterStrike2GSI/releases/latest)
 [![NuGet Version](https://img.shields.io/nuget/v/CounterStrike2GSI)](https://www.nuget.org/packages/CounterStrike2GSI)
+[![NuGet Downloads](https://img.shields.io/nuget/dt/CounterStrike2GSI?label=nuget%20downloads)](https://www.nuget.org/packages/CounterStrike2GSI)
 
 A C# library to interface with the Game State Integration found in Counter-Strike 2.
 
@@ -32,43 +33,7 @@ Install from [nuget](https://www.nuget.org/packages/CounterStrike2GSI).
 
 ## How to use
 
-1. Before `CounterStrike2GSI` can be used, you must create a Game State Integration configuration file where you would specify the URI for the HTTP Requests and select which providers the game should expose to your application. To do this you must create a new configuration file in `<PATH TO GAME DIRECTORY>/game/csgo/cfg/gamestate_integration_<CUSTOM NAME>.cfg` where `<CUSTOM NAME>` should be the name of your application (it can be anything). Add the following content to your configuration file (make sure you replace `<CUSTOM NAME>` with your application's name, `<CUSTOM PORT>` with the port you would like to use for your application, and other values can also be tweaked as you wish):
-```
-"<CUSTOM NAME> Integration Configuration"
-{
-    "uri" "http://localhost:<CUSTOM PORT>/"
-    "timeout" "5.0"
-    "buffer"  "0.1"
-    "throttle" "0.5"
-    "heartbeat" "10.0"
-    "auth"
-    {
-    }
-    "data"
-    {
-        "provider"               "1"
-        "tournamentdraft"        "1"
-        "map"                    "1"
-        "map_round_wins"         "1"
-        "round"                  "1"
-        "player_id"              "1"
-        "player_state"           "1"
-        "player_weapons"         "1"
-        "player_match_stats"     "1"
-        "player_position"        "1"
-        "phase_countdowns"       "1"
-        "allplayers_id"          "1"
-        "allplayers_state"       "1"
-        "allplayers_match_stats" "1"
-        "allplayers_weapons"     "1"
-        "allplayers_position"    "1"
-        "allgrenades"            "1"
-        "bomb"                   "1"
-    }
-}
-```
-
-2. After installing the [CounterStrike2GSI nuget package](https://www.nuget.org/packages/CounterStrike2GSI) in your project, create an instance of `GameStateListener`, providing a custom port or custom URI you defined in the configuration file in the previous step.
+1. After installing the [CounterStrike2GSI nuget package](https://www.nuget.org/packages/CounterStrike2GSI) in your project, create an instance of `GameStateListener`, providing a custom port or custom URI you defined in the configuration file in the previous step.
 ```C#
 GameStateListener gsl = new GameStateListener(3000); //http://localhost:3000/
 ```
@@ -77,6 +42,46 @@ or
 GameStateListener gsl = new GameStateListener("http://127.0.0.1:1234/");
 ```
 > **Please note**: If your application needs to listen to a URI other than `http://localhost:*/` (for example `http://192.168.0.2:100/`), you will need to run your application with administrator privileges.
+
+2. Create a Game State Integration configuration file. This can either be done manually by creating a file `<PATH TO GAME DIRECTORY>/game/csgo/cfg/gamestate_integration_<CUSTOM NAME>.cfg` where `<CUSTOM NAME>` should be the name of your application (it can be anything). Or you can use the built-in function `GenerateGSIConfigFile()` to automatically locate the game directory and generate the file. The function will automatically take into consideration the URI specified when a `GameStateListener` instance was created in the previous step.
+```C#
+if (!gsl.GenerateGSIConfigFile("Example"))
+{
+    Console.WriteLine("Could not generate GSI configuration file.");
+}
+```
+The function `GenerateGSIConfigFile` takes a string `name` as the parameter. This is the `<CUSTOM NAME>` mentioned earlier. The function will also return `True` when file generation was successful, and `False` otherwise. The resulting file from the above code should look like this:
+```
+"Example Integration Configuration"
+{
+    "uri"          "http://localhost:3000/"
+    "timeout"      "5.0"
+    "buffer"       "0.1"
+    "throttle"     "0.1"
+    "heartbeat"    "10.0"
+    "data"
+    {
+        "provider"                  "1"
+        "tournamentdraft"           "1"
+        "map"                       "1"
+        "map_round_wins"            "1"
+        "round"                     "1"
+        "player_id"                 "1"
+        "player_state"              "1"
+        "player_weapons"            "1"
+        "player_match_stats"        "1"
+        "player_position"           "1"
+        "phase_countdowns"          "1"
+        "allplayers_id"             "1"
+        "allplayers_state"          "1"
+        "allplayers_match_stats"    "1"
+        "allplayers_weapons"        "1"
+        "allplayers_position"       "1"
+        "allgrenades"               "1"
+        "bomb"                      "1"
+    }
+}
+```
 
 3. Create handlers and subscribe for events your application will be using. (A full list of exposed Game Events can be found in the [Implemented Game Events](#implemented-game-events) section.)
 If your application just needs `GameState` information, this is done by subscribing to `NewGameState` event and creating a handler for it:
@@ -352,6 +357,6 @@ In the event that the game state is missing information, a default value will be
 | `string` | `String.Empty` |
 | `enum`   | `Undefined`    |
 
-### Weapon names
+## Weapon names
 
 A full list of weapon names can be found [here](https://counterstrike.fandom.com/wiki/Developer_console#Available_entities).


### PR DESCRIPTION
Allows the `GameStateListener` to generate a GSI configuration file keeping in mind the URI/Port context specified when a `GameStateListener` was created.

The readme has been updated with instructions on how to generate the GSI configuration file.