### PR TITLE
Add more Map events

### DIFF
--- a/CounterStrike2GSI/CS2EventsInterface.cs
+++ b/CounterStrike2GSI/CS2EventsInterface.cs
@@ -116,10 +116,25 @@ namespace CounterStrike2GSI
         /// <inheritdoc cref="CounterStrike2GSI.EventMessages.MapUpdated" />
         public event MapUpdatedHandler MapUpdated = delegate { };
 
+        public delegate void GamemodeChangedHandler(GamemodeChanged game_event);
+
+        /// <inheritdoc cref="CounterStrike2GSI.EventMessages.GamemodeChanged" />
+        public event GamemodeChangedHandler GamemodeChanged = delegate { };
+
         public delegate void TeamStatisticsUpdatedHandler(TeamStatisticsUpdated game_event);
 
         /// <inheritdoc cref="CounterStrike2GSI.EventMessages.TeamStatisticsUpdated" />
         public event TeamStatisticsUpdatedHandler TeamStatisticsUpdated = delegate { };
+
+        public delegate void TeamScoreChangedHandler(TeamScoreChanged game_event);
+
+        /// <inheritdoc cref="CounterStrike2GSI.EventMessages.TeamScoreChanged" />
+        public event TeamScoreChangedHandler TeamScoreChanged = delegate { };
+
+        public delegate void TeamRemainingTimeoutsChangedHandler(TeamRemainingTimeoutsChanged game_event);
+
+        /// <inheritdoc cref="CounterStrike2GSI.EventMessages.TeamRemainingTimeoutsChanged" />
+        public event TeamRemainingTimeoutsChangedHandler TeamRemainingTimeoutsChanged = delegate { };
 
         public delegate void RoundChangedHandler(RoundChanged game_event);
 
@@ -140,6 +155,71 @@ namespace CounterStrike2GSI
 
         /// <inheritdoc cref="CounterStrike2GSI.EventMessages.LevelChanged" />
         public event LevelChangedHandler LevelChanged = delegate { };
+
+        public delegate void MapPhaseChangedHandler(MapPhaseChanged game_event);
+
+        /// <inheritdoc cref="CounterStrike2GSI.EventMessages.MapPhaseChanged" />
+        public event MapPhaseChangedHandler MapPhaseChanged = delegate { };
+
+        public delegate void WarmupStartedHandler(WarmupStarted game_event);
+
+        /// <inheritdoc cref="CounterStrike2GSI.EventMessages.WarmupStarted" />
+        public event WarmupStartedHandler WarmupStarted = delegate { };
+
+        public delegate void WarmupOverHandler(WarmupOver game_event);
+
+        /// <inheritdoc cref="CounterStrike2GSI.EventMessages.WarmupOver" />
+        public event WarmupOverHandler WarmupOver = delegate { };
+
+        public delegate void IntermissionStartedHandler(IntermissionStarted game_event);
+
+        /// <inheritdoc cref="CounterStrike2GSI.EventMessages.IntermissionStarted" />
+        public event IntermissionStartedHandler IntermissionStarted = delegate { };
+
+        public delegate void IntermissionOverHandler(IntermissionOver game_event);
+
+        /// <inheritdoc cref="CounterStrike2GSI.EventMessages.IntermissionOver" />
+        public event IntermissionOverHandler IntermissionOver = delegate { };
+
+        public delegate void FreezetimeStartedHandler(FreezetimeStarted game_event);
+
+        /// <inheritdoc cref="CounterStrike2GSI.EventMessages.FreezetimeStarted" />
+        public event FreezetimeStartedHandler FreezetimeStarted = delegate { };
+
+        public delegate void FreezetimeOverHandler(FreezetimeOver game_event);
+
+        /// <inheritdoc cref="CounterStrike2GSI.EventMessages.FreezetimeOver" />
+        public event FreezetimeOverHandler FreezetimeOver = delegate { };
+
+        public delegate void PauseStartedHandler(PauseStarted game_event);
+
+        /// <inheritdoc cref="CounterStrike2GSI.EventMessages.PauseStarted" />
+        public event PauseStartedHandler PauseStarted = delegate { };
+
+        public delegate void PauseOverHandler(PauseOver game_event);
+
+        /// <inheritdoc cref="CounterStrike2GSI.EventMessages.PauseOver" />
+        public event PauseOverHandler PauseOver = delegate { };
+
+        public delegate void TimeoutStartedHandler(TimeoutStarted game_event);
+
+        /// <inheritdoc cref="CounterStrike2GSI.EventMessages.TimeoutStarted" />
+        public event TimeoutStartedHandler TimeoutStarted = delegate { };
+
+        public delegate void TimeoutOverHandler(TimeoutOver game_event);
+
+        /// <inheritdoc cref="CounterStrike2GSI.EventMessages.TimeoutOver" />
+        public event TimeoutOverHandler TimeoutOver = delegate { };
+
+        public delegate void MatchStartedHandler(MatchStarted game_event);
+
+        /// <inheritdoc cref="CounterStrike2GSI.EventMessages.MatchStarted" />
+        public event MatchStartedHandler MatchStarted = delegate { };
+
+        public delegate void GameoverHandler(Gameover game_event);
+
+        /// <inheritdoc cref="CounterStrike2GSI.EventMessages.Gameover" />
+        public event GameoverHandler Gameover = delegate { };
 
         #endregion
 
@@ -442,9 +522,24 @@ namespace CounterStrike2GSI
                 RaiseEvent(MapUpdated, e);
             }
 
+            if (e is GamemodeChanged)
+            {
+                RaiseEvent(GamemodeChanged, e);
+            }
+
             if (e is TeamStatisticsUpdated)
             {
                 RaiseEvent(TeamStatisticsUpdated, e);
+            }
+
+            if (e is TeamScoreChanged)
+            {
+                RaiseEvent(TeamScoreChanged, e);
+            }
+
+            if (e is TeamRemainingTimeoutsChanged)
+            {
+                RaiseEvent(TeamRemainingTimeoutsChanged, e);
             }
 
             if (e is RoundChanged)
@@ -465,6 +560,71 @@ namespace CounterStrike2GSI
             if (e is LevelChanged)
             {
                 RaiseEvent(LevelChanged, e);
+            }
+
+            if (e is MapPhaseChanged)
+            {
+                RaiseEvent(MapPhaseChanged, e);
+            }
+
+            if (e is WarmupStarted)
+            {
+                RaiseEvent(WarmupStarted, e);
+            }
+
+            if (e is WarmupOver)
+            {
+                RaiseEvent(WarmupOver, e);
+            }
+
+            if (e is IntermissionStarted)
+            {
+                RaiseEvent(IntermissionStarted, e);
+            }
+
+            if (e is IntermissionOver)
+            {
+                RaiseEvent(IntermissionOver, e);
+            }
+
+            if (e is FreezetimeStarted)
+            {
+                RaiseEvent(FreezetimeStarted, e);
+            }
+
+            if (e is FreezetimeOver)
+            {
+                RaiseEvent(FreezetimeOver, e);
+            }
+
+            if (e is PauseStarted)
+            {
+                RaiseEvent(PauseStarted, e);
+            }
+
+            if (e is PauseOver)
+            {
+                RaiseEvent(PauseOver, e);
+            }
+
+            if (e is TimeoutStarted)
+            {
+                RaiseEvent(TimeoutStarted, e);
+            }
+
+            if (e is TimeoutOver)
+            {
+                RaiseEvent(TimeoutOver, e);
+            }
+
+            if (e is MatchStarted)
+            {
+                RaiseEvent(MatchStarted, e);
+            }
+
+            if (e is Gameover)
+            {
+                RaiseEvent(Gameover, e);
             }
 
             if (e is PhaseCountdownsUpdated)

--- a/CounterStrike2GSI/EventMessages/MapEvents.cs
+++ b/CounterStrike2GSI/EventMessages/MapEvents.cs
@@ -13,11 +13,41 @@ namespace CounterStrike2GSI.EventMessages
     }
 
     /// <summary>
+    /// Event for gamemode changing. 
+    /// </summary>
+    public class GamemodeChanged : UpdateEvent<GameMode>
+    {
+        public GamemodeChanged(GameMode new_value, GameMode previous_value) : base(new_value, previous_value)
+        {
+        }
+    }
+
+    /// <summary>
     /// Event for specific team's Statistics update.
     /// </summary>
     public class TeamStatisticsUpdated : TeamUpdateEvent<TeamStatistics>
     {
         public TeamStatisticsUpdated(TeamStatistics new_value, TeamStatistics previous_value, PlayerTeam team) : base(new_value, previous_value, team)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Event for specific team's score change.
+    /// </summary>
+    public class TeamScoreChanged : TeamUpdateEvent<int>
+    {
+        public TeamScoreChanged(int new_value, int previous_value, PlayerTeam team) : base(new_value, previous_value, team)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Event for specific team's remaining timeouts change.
+    /// </summary>
+    public class TeamRemainingTimeoutsChanged : TeamUpdateEvent<int>
+    {
+        public TeamRemainingTimeoutsChanged(int new_value, int previous_value, PlayerTeam team) : base(new_value, previous_value, team)
         {
         }
     }
@@ -106,6 +136,148 @@ namespace CounterStrike2GSI.EventMessages
     public class LevelChanged : UpdateEvent<string>
     {
         public LevelChanged(string new_value, string previous_value) : base(new_value, previous_value)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Event for Map phase change.
+    /// </summary>
+    public class MapPhaseChanged : UpdateEvent<Phase>
+    {
+        public MapPhaseChanged(Phase new_value, Phase previous_value) : base(new_value, previous_value)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Event for game Warmup starting.
+    /// </summary>
+    public class WarmupStarted : CS2GameEvent
+    {
+        public WarmupStarted() : base()
+        {
+        }
+    }
+
+    /// <summary>
+    /// Event for game Warmup ending.
+    /// </summary>
+    public class WarmupOver : CS2GameEvent
+    {
+        public WarmupOver() : base()
+        {
+        }
+    }
+
+    /// <summary>
+    /// Event for game Intermission (or half-time intermission) starting.
+    /// </summary>
+    public class IntermissionStarted : CS2GameEvent
+    {
+        public IntermissionStarted() : base()
+        {
+        }
+    }
+
+    /// <summary>
+    /// Event for game Intermission (or half-time intermission) ending.
+    /// </summary>
+    public class IntermissionOver : CS2GameEvent
+    {
+        public IntermissionOver() : base()
+        {
+        }
+    }
+
+    /// <summary>
+    /// Event for game Freezetime starting.
+    /// </summary>
+    public class FreezetimeStarted : CS2GameEvent
+    {
+        public FreezetimeStarted() : base()
+        {
+        }
+    }
+
+    /// <summary>
+    /// Event for game Freezetime ending.
+    /// </summary>
+    public class FreezetimeOver : CS2GameEvent
+    {
+        public FreezetimeOver() : base()
+        {
+        }
+    }
+
+    /// <summary>
+    /// Event for game Pause starting.
+    /// </summary>
+    public class PauseStarted : CS2GameEvent
+    {
+        public PauseStarted() : base()
+        {
+        }
+    }
+
+    /// <summary>
+    /// Event for game Pause ending.
+    /// </summary>
+    public class PauseOver : CS2GameEvent
+    {
+        public PauseOver() : base()
+        {
+        }
+    }
+
+    /// <summary>
+    /// Event for game Timeout starting.
+    /// </summary>
+    public class TimeoutStarted : CS2GameEvent
+    {
+        /// <summary>
+        /// The team the timeout is started by.
+        /// </summary>
+        public readonly PlayerTeam Team;
+
+        public TimeoutStarted(PlayerTeam team) : base()
+        {
+            Team = team;
+        }
+    }
+
+    /// <summary>
+    /// Event for game Timeout ending.
+    /// </summary>
+    public class TimeoutOver : CS2GameEvent
+    {
+        /// <summary>
+        /// The team the timeout is started by.
+        /// </summary>
+        public readonly PlayerTeam Team;
+
+        public TimeoutOver(PlayerTeam team) : base()
+        {
+            Team = team;
+        }
+    }
+
+    /// <summary>
+    /// Event for game Match starting (or resuming).
+    /// </summary>
+    public class MatchStarted : CS2GameEvent
+    {
+        public MatchStarted() : base()
+        {
+        }
+    }
+
+    /// <summary>
+    /// Event for game being over.
+    /// </summary>
+    public class Gameover : CS2GameEvent
+    {
+        public Gameover() : base()
         {
         }
     }

--- a/CounterStrike2GSI/Nodes/Round.cs
+++ b/CounterStrike2GSI/Nodes/Round.cs
@@ -39,39 +39,24 @@ namespace CounterStrike2GSI.Nodes
         Undefined = -1,
 
         /// <summary>
-        /// Freeze time.
+        /// The game is in freeze time.
         /// </summary>
         Freezetime,
 
         /// <summary>
-        /// The round is undergoing.
+        /// The round or game is undergoing.
         /// </summary>
         Live,
+
+        /// <summary>
+        /// The game is in warmup.
+        /// </summary>
+        Warmup,
 
         /// <summary>
         /// The game is paused.
         /// </summary>
         Paused,
-
-        /// <summary>
-        /// The round is over.
-        /// </summary>
-        Over,
-
-        /// <summary>
-        /// The game is in intermission.
-        /// </summary>
-        Intermission,
-
-        /// <summary>
-        /// The game is over.
-        /// </summary>
-        Gameover,
-
-        /// <summary>
-        /// The round is over by bomb detonation.
-        /// </summary>
-        Bomb,
 
         /// <summary>
         /// The game is paused by Terrorist timeout.
@@ -84,14 +69,29 @@ namespace CounterStrike2GSI.Nodes
         Timeout_CT,
 
         /// <summary>
+        /// The game is over.
+        /// </summary>
+        Gameover,
+
+        /// <summary>
+        /// The game is in intermission.
+        /// </summary>
+        Intermission,
+
+        /// <summary>
+        /// The round is over.
+        /// </summary>
+        Over,
+
+        /// <summary>
+        /// The round is over by bomb detonation.
+        /// </summary>
+        Bomb,
+
+        /// <summary>
         /// The round is over by bomb defusal.
         /// </summary>
         Defuse,
-
-        /// <summary>
-        /// The game is in warmup.
-        /// </summary>
-        Warmup
     }
 
     /// <summary>


### PR DESCRIPTION
Add more events from `MapUpdated` event.

Added events:
* `GamemodeChanged`
* `TeamScoreChanged`
* `TeamRemainingTimeoutsChanged`
* `MapPhaseChanged`
* `WarmupStarted`
* `WarmupOver`
* `IntermissionStarted`
* `IntermissionOver`
* `FreezetimeStarted`
* `FreezetimeOver`
* `PauseStarted`
* `PauseOver`
* `TimeoutStarted`
* `TimeoutOver`
* `MatchStarted`
* `Gameover`